### PR TITLE
Modified title field for SectionsTable to link to details page

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -16,6 +16,8 @@ import {
   formatStatus,
   formatInfoLink,
   renderInfoLink,
+  formatTitleLink,
+  renderTitleLink,
 } from "main/utils/sectionUtils.js";
 
 function getFirstVal(values) {
@@ -161,11 +163,11 @@ export default function SectionsTable({ sections }) {
     },
     {
       Header: "Title",
-      accessor: "courseInfo.title",
-      disableGroupBy: true,
-
+      accessor: formatTitleLink,
+      cell: renderTitleLink,
+      
       aggregate: getFirstVal,
-      Aggregated: ({ cell: { value } }) => `${value}`,
+      Aggregated: renderTitleLink,
     },
     {
       // Stryker disable next-line StringLiteral: this column is hidden, very hard to test

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -104,3 +104,15 @@ export const renderInfoLink = ({ cell: { value } }) => (
     </a>
   </p>
 );
+
+export const formatTitleLink = (row) => (
+  <a href={`/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`} >
+      {row.courseInfo.title}
+  </a>
+);
+
+export const renderTitleLink = ({ cell: { value } }) => (
+   <p align="center">
+      {value}
+  </p>
+);

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -567,7 +567,7 @@ describe("Section tests", () => {
     const expectedFields = [
       "quarter",
       "courseInfo.courseId",
-      "courseInfo.title",
+      "Title",
       "status",
       "enrolled",
       "location",
@@ -642,7 +642,7 @@ describe("Section tests", () => {
     const expectedFields = [
       "quarter",
       "courseInfo.courseId",
-      "courseInfo.title",
+      "Title",
       "status",
       "enrolled",
       "location",
@@ -667,8 +667,12 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
     ).toHaveTextContent("ECE 1A");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`),
+      screen.getByTestId(`${testId}-cell-row-0-col-Title`),
     ).toHaveTextContent("COMP ENGR SEMINAR");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Title`)
+        .querySelector('a[href$="/coursedetails/20221/12583"]'),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-quarter`),
     ).toHaveTextContent("W22");


### PR DESCRIPTION
Title field in SectionsTable in Basic Search now links to the associated course's details page. 

![image](https://github.com/user-attachments/assets/f508be9b-05c4-4c8d-a31b-8ba55a76181d)



Closes #3 